### PR TITLE
Renamed validate password method

### DIFF
--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -98,7 +98,7 @@ const userSchema = new Schema({
   }
 });
 
-userSchema.methods.validateNewPassword = function (password) {
+userSchema.methods.confirmPassword = function (password) {
   return new Promise((resolve, reject) => {
     bcrypt
       .compare(password, this.password)

--- a/src/database/models/user.spec.js
+++ b/src/database/models/user.spec.js
@@ -165,7 +165,7 @@ describe('User schema', () => {
       dateLastLoggedIn: new Date()
     });
     user.setPassword('1234567').then(() => {
-      user.validateNewPassword('1234567').then(() => {
+      user.confirmPassword('1234567').then(() => {
         expect(user.password).not.toEqual('1234567');
         done();
       });
@@ -228,7 +228,7 @@ describe('User schema', () => {
     });
 
     user.setPassword('1234567')
-      .then(() => user.validateNewPassword('abc'))
+      .then(() => user.confirmPassword('abc'))
       .catch(err => {
         expect(err.message).toEqual('Password invalid.');
         done();

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -227,7 +227,7 @@ const resetPassword = [
         .then((user) => updatePasswordForUser(user)(req, res, next))
         .catch((err) => handleError(err, next));
     } else {
-      req.user.validateNewPassword(req.body.currentPassword)
+      req.user.confirmPassword(req.body.currentPassword)
         .then((user) => updatePasswordForUser(req.user)(req, res, next))
         .catch((err) => handleError(err, next));
     }

--- a/src/routes/auth.spec.js
+++ b/src/routes/auth.spec.js
@@ -431,7 +431,7 @@ describe('Auth router', () => {
         setPassword: () => Promise.resolve(_req.user),
         save: () => Promise.resolve(),
         unsetResetPasswordToken: () => {},
-        validateNewPassword: () => Promise.resolve()
+        confirmPassword: () => Promise.resolve()
       };
       _req = {
         body: {},
@@ -458,7 +458,7 @@ describe('Auth router', () => {
       const resetPassword = auth.middleware.resetPassword;
       const unsetTokenSpy = spyOn(_req.user, 'unsetResetPasswordToken')
         .and.callThrough();
-      const validateNewPasswordSpy = spyOn(_req.user, 'validateNewPassword')
+      const confirmPasswordSpy = spyOn(_req.user, 'confirmPassword')
         .and.callThrough();
       const setPasswordSpy = spyOn(_req.user, 'setPassword')
         .and.callThrough();
@@ -469,7 +469,7 @@ describe('Auth router', () => {
       const res = {
         json: () => {
           expect(unsetTokenSpy).toHaveBeenCalledWith();
-          expect(validateNewPasswordSpy)
+          expect(confirmPasswordSpy)
             .toHaveBeenCalledWith(_req.body.currentPassword);
           expect(setPasswordSpy).toHaveBeenCalledWith(_req.body.password);
           done();

--- a/src/strategies/local.js
+++ b/src/strategies/local.js
@@ -20,7 +20,7 @@ const verify = (emailAddress, password, done) => {
       }
 
       user
-        .validateNewPassword(password)
+        .confirmPassword(password)
         .then(() => {
           user.dateLastLoggedIn = new Date();
           user

--- a/src/strategies/local.spec.js
+++ b/src/strategies/local.spec.js
@@ -31,7 +31,7 @@ describe('local passport strategy', () => {
 
   it('should pass if the email address and password match a record', (done) => {
     const mockUser = {
-      validateNewPassword: () => Promise.resolve(),
+      confirmPassword: () => Promise.resolve(),
       save: () => Promise.resolve()
     };
     mock('passport-local', {
@@ -65,7 +65,7 @@ describe('local passport strategy', () => {
 
   it('should fail if the password is invalid', (done) => {
     const mockUser = {
-      validateNewPassword: () => Promise.reject(new Error()),
+      confirmPassword: () => Promise.reject(new Error()),
       save: () => Promise.resolve()
     };
     mock('passport-local', {


### PR DESCRIPTION
`validateNewPassword` doesn't make sense because it is confirming the input password against the user's _current_ password.